### PR TITLE
Fix rev_hash when running cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ find_package(PCHSupport)
 find_package(ACE REQUIRED)
 find_package(MySQL REQUIRED)
 find_package(OpenSSL REQUIRED)
+find_package(Git)
 
 # Find revision ID and hash of the sourcetree
 include(cmake/genrev.cmake)

--- a/cmake/macros/FindGit.cmake
+++ b/cmake/macros/FindGit.cmake
@@ -1,0 +1,46 @@
+# Copyright (C) 2008-2017 TrinityCore <http://www.trinitycore.org/>
+#
+# This file is free software; as a special exception the author gives
+# unlimited permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+include(${CMAKE_SOURCE_DIR}/cmake/macros/EnsureVersion.cmake)
+
+set(_REQUIRED_GIT_VERSION "1.7")
+
+find_program(GIT_EXECUTABLE
+  NAMES
+    git git.cmd
+  HINTS
+    ENV PATH
+  DOC "Full path to git commandline client"
+)
+MARK_AS_ADVANCED(GIT_EXECUTABLE)
+
+if(NOT GIT_EXECUTABLE)
+  message(FATAL_ERROR "
+    Git was NOT FOUND on your system - did you forget to install a recent version, or setting the path to it?
+    Observe that for revision hash/date to work you need at least version ${_REQUIRED_GIT_VERSION}")
+else()
+  message(STATUS "Found git binary : ${GIT_EXECUTABLE}")
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" --version
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE _GIT_VERSION
+    ERROR_QUIET
+  )
+
+  # make sure we're using minimum the required version of git, so the "dirty-testing" will work properly
+  ensure_version( "${_REQUIRED_GIT_VERSION}" "${_GIT_VERSION}" _GIT_VERSION_OK)
+
+  # throw an error if we don't have a recent enough version of git...
+  if(NOT _GIT_VERSION_OK)
+    message(STATUS "Git version too old : ${_GIT_VERSION}")
+    message(FATAL_ERROR "
+      Git was found but is OUTDATED - did you forget to install a recent version, or setting the path to it?
+      Observe that for revision hash/date to work you need at least version ${_REQUIRED_GIT_VERSION}")
+  endif()
+endif()

--- a/revision.h.in.cmake
+++ b/revision.h.in.cmake
@@ -2,8 +2,8 @@
 #define __REVISION_H__
  #define _HASH                      "@rev_hash@"
  #define _DATE                      "@rev_date@"
- #define VER_COMPANYNAME_STR        "WoWSource Developers"
- #define VER_LEGALCOPYRIGHT_STR     "(c)2012-2015 WoWSource"
+ #define VER_COMPANYNAME_STR        "MoPCore Developers"
+ #define VER_LEGALCOPYRIGHT_STR     "(c)2012-2017 TrinityCore"
  #define VER_FILEVERSION            0,0,0
  #define VER_FILEVERSION_STR        "@rev_date@ (@rev_hash@)"
  #define VER_PRODUCTVERSION         VER_FILEVERSION


### PR DESCRIPTION
Need to use 'git tag -a -m "Initial tag" init' to make it works. Taken from TrinityCore.